### PR TITLE
fix KeyError: 'kind'

### DIFF
--- a/rplugin/python3/deoplete/source/vim_lsc.py
+++ b/rplugin/python3/deoplete/source/vim_lsc.py
@@ -62,7 +62,7 @@ class Source(Base):
             'abbr': item['insertText'] if item.get('insertText', None) else item['label'],
             'menu': item['detail'] if item.get('detail', None) else item['label'],
             'info': item['detail'] if item.get('detail', None) else item['label'],
-            'kind': COMPLETION_ITEM_KIND[item['kind'] - 1]
+            'kind': COMPLETION_ITEM_KIND[item.get('kind', 1) - 1]
         } for item in items]
         return candidates
 


### PR DESCRIPTION
I figured item doesn't always have key 'kind'

```
[deoplete] Traceback (most recent call last):
  File ".../.local/share/nvim/plugged/deoplete.nvim/rplugin/python3/deoplete/child.py", line 194, in _gather_results
    result = self._get_result(context, source)
  File ".../.local/share/nvim/plugged/deoplete.nvim/rplugin/python3/deoplete/child.py", line 254, in _get_result
    ctx['candidates'] = source.gather_candidates(ctx)
  File ".../.local/share/nvim/plugged/deoplete-vim-lsc/rplugin/python3/deoplete/source/vim_lsc.py", line 52, in gather_candidates
    return self.to_candidates(request['response'])
  File ".../.local/share/nvim/plugged/deoplete-vim-lsc/rplugin/python3/deoplete/source/vim_lsc.py", line 66, in to_candidates
    } for item in items]
  File ".../.local/share/nvim/plugged/deoplete-vim-lsc/rplugin/python3/deoplete/source/vim_lsc.py", line 66, in <listcomp>
    } for item in items]
KeyError: 'kind'
Error from lsc: 'kind'.  Use :messages / see above for error details.
```